### PR TITLE
Some enhancements

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,5 @@
+<resources>
+
+    <string name="app_name" translatable="false">Android N-ify</string>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
 
-    <string name="app_name" translatable="false">Android N-ify</string>
     <string name="xposed_description">Ports back features introduced in Android N to Lollipop and Marshmallow!</string>
 
     <string name="header_app">App</string>


### PR DESCRIPTION
I moved "app_name" string from string.xml file to donottranslate.xml file, so when traslators translate this module, they use only strings.xml , avoiding adding an "app_name" string in the translation :+1: 