### PR TITLE
Fix for SW double-tap speed settings

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapBase.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapBase.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 
 import java.util.List;
 
+import de.robv.android.xposed.XSharedPreferences;
 import tk.wasdennnoch.androidn_ify.R;
 import tk.wasdennnoch.androidn_ify.XposedHook;
 import tk.wasdennnoch.androidn_ify.ui.SettingsActivity;
@@ -21,7 +22,7 @@ public class DoubleTapBase {
 
     private static final String TAG = "DoubleTapBase";
     private static ActivityManager mAm;
-    protected static int mDoubletapSpeed = 400;
+    protected static int mDoubletapSpeed = 180;
 
     private static BroadcastReceiver sBroadcastReceiver = new BroadcastReceiver() {
         @Override
@@ -30,7 +31,7 @@ public class DoubleTapBase {
             switch (intent.getAction()) {
                 case SettingsActivity.ACTION_RECENTS_CHANGED:
                     if (intent.hasExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED))
-                        mDoubletapSpeed = intent.getIntExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED, 120);
+                        mDoubletapSpeed = intent.getIntExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED, 180);
                     break;
                 case SettingsActivity.ACTION_GENERAL:
                     if (intent.hasExtra(SettingsActivity.EXTRA_GENERAL_DEBUG_LOG))
@@ -39,6 +40,10 @@ public class DoubleTapBase {
             }
         }
     };
+
+    protected static void loadPrefDoubleTapSpeed(XSharedPreferences prefs) {
+        mDoubletapSpeed = prefs.getInt("double_tap_speed", 180);
+    }
 
     protected static void registerReceiver(final Context context) {
         IntentFilter intentFilter = new IntentFilter();

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapBase.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapBase.java
@@ -1,8 +1,10 @@
 package tk.wasdennnoch.androidn_ify.recents.doubletap;
 
 import android.app.ActivityManager;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
 import android.os.Handler;
@@ -12,6 +14,7 @@ import java.util.List;
 
 import tk.wasdennnoch.androidn_ify.R;
 import tk.wasdennnoch.androidn_ify.XposedHook;
+import tk.wasdennnoch.androidn_ify.ui.SettingsActivity;
 import tk.wasdennnoch.androidn_ify.utils.StringUtils;
 
 public class DoubleTapBase {
@@ -19,6 +22,30 @@ public class DoubleTapBase {
     private static final String TAG = "DoubleTapBase";
     private static ActivityManager mAm;
     protected static int mDoubletapSpeed = 400;
+
+    private static BroadcastReceiver sBroadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            XposedHook.logD(TAG, "Broadcast received: " + intent);
+            switch (intent.getAction()) {
+                case SettingsActivity.ACTION_RECENTS_CHANGED:
+                    if (intent.hasExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED))
+                        mDoubletapSpeed = intent.getIntExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED, 120);
+                    break;
+                case SettingsActivity.ACTION_GENERAL:
+                    if (intent.hasExtra(SettingsActivity.EXTRA_GENERAL_DEBUG_LOG))
+                        XposedHook.debug = intent.getBooleanExtra(SettingsActivity.EXTRA_GENERAL_DEBUG_LOG, false);
+                    break;
+            }
+        }
+    };
+
+    protected static void registerReceiver(final Context context) {
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(SettingsActivity.ACTION_RECENTS_CHANGED);
+        intentFilter.addAction(SettingsActivity.ACTION_GENERAL);
+        context.registerReceiver(sBroadcastReceiver, intentFilter);
+    }
 
     private static ActivityManager getActivityManager(Context context) {
         if (mAm == null) {

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapHwKeys.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapHwKeys.java
@@ -1,9 +1,6 @@
 package tk.wasdennnoch.androidn_ify.recents.doubletap;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.hardware.input.InputManager;
 import android.os.Build;
 import android.os.Handler;
@@ -14,7 +11,6 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XSharedPreferences;
 import de.robv.android.xposed.XposedHelpers;
 import tk.wasdennnoch.androidn_ify.XposedHook;
-import tk.wasdennnoch.androidn_ify.ui.SettingsActivity;
 
 public class DoubleTapHwKeys extends DoubleTapBase {
 
@@ -42,22 +38,6 @@ public class DoubleTapHwKeys extends DoubleTapBase {
             injectKey(KeyEvent.KEYCODE_APP_SWITCH);
         }
     };
-    private static BroadcastReceiver sBroadcastReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            XposedHook.logD(TAG, "Broadcast received: " + intent);
-            switch (intent.getAction()) {
-                case SettingsActivity.ACTION_RECENTS_CHANGED:
-                    if (intent.hasExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED))
-                        mDoubletapSpeed = intent.getIntExtra(SettingsActivity.EXTRA_RECENTS_DOUBLE_TAP_SPEED, 400);
-                    break;
-                case SettingsActivity.ACTION_GENERAL:
-                    if (intent.hasExtra(SettingsActivity.EXTRA_GENERAL_DEBUG_LOG))
-                        XposedHook.debug = intent.getBooleanExtra(SettingsActivity.EXTRA_GENERAL_DEBUG_LOG, false);
-                    break;
-            }
-        }
-    };
 
     private static XC_MethodHook initHook = new XC_MethodHook() {
         @Override
@@ -66,10 +46,7 @@ public class DoubleTapHwKeys extends DoubleTapBase {
             mContext = (Context) XposedHelpers.getObjectField(mPhoneWindowManager, "mContext");
             mHandler = (Handler) XposedHelpers.getObjectField(mPhoneWindowManager, "mHandler");
             // No need to unregister this because the system process will last "forever"
-            IntentFilter intentFilter = new IntentFilter();
-            intentFilter.addAction(SettingsActivity.ACTION_RECENTS_CHANGED);
-            intentFilter.addAction(SettingsActivity.ACTION_GENERAL);
-            mContext.registerReceiver(sBroadcastReceiver, intentFilter);
+            registerReceiver(mContext);
         }
     };
     private static XC_MethodHook interceptKeyBeforeDispatchingHook = new XC_MethodHook() {

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapHwKeys.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapHwKeys.java
@@ -89,6 +89,7 @@ public class DoubleTapHwKeys extends DoubleTapBase {
             XposedHelpers.findAndHookMethod(classPhoneWindowManager, "init", Context.class, CLASS_IWINDOW_MANAGER, CLASS_WINDOW_MANAGER_FUNCS, initHook);
 
             prefs.reload();
+            loadPrefDoubleTapSpeed(prefs);
             if (prefs.getBoolean("enable_recents_tweaks", true)) {
 
                 XposedHelpers.findAndHookMethod(classPhoneWindowManager, "interceptKeyBeforeDispatching", CLASS_WINDOW_STATE, KeyEvent.class, int.class, interceptKeyBeforeDispatchingHook);

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapSwKeys.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapSwKeys.java
@@ -64,6 +64,7 @@ public class DoubleTapSwKeys extends DoubleTapBase {
         try {
 
             prefs.reload();
+            loadPrefDoubleTapSpeed(prefs);
             if (prefs.getBoolean("enable_recents_tweaks", true)) {
 
                 Class<?> classPhoneStatusBar = XposedHelpers.findClass(CLASS_PHONE_STATUS_BAR, classLoader);

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapSwKeys.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/recents/doubletap/DoubleTapSwKeys.java
@@ -26,10 +26,14 @@ public class DoubleTapSwKeys extends DoubleTapBase {
             sOriginalRecentsClickListener.onClick(sRecentsButton);
         }
     };
+
     private static XC_MethodHook prepareNavigationBarViewHook = new XC_MethodHook() {
         @Override
         protected void afterHookedMethod(MethodHookParam param) throws Throwable {
             final Context mContext = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+
+            registerReceiver(mContext);
+
             if (!isTaskLocked(mContext)) {
                 final Handler mHandler = (Handler) XposedHelpers.getObjectField(param.thisObject, "mHandler");
                 sOriginalRecentsClickListener = (View.OnClickListener) XposedHelpers.getObjectField(param.thisObject, "mRecentsClickListener");
@@ -64,7 +68,6 @@ public class DoubleTapSwKeys extends DoubleTapBase {
 
                 Class<?> classPhoneStatusBar = XposedHelpers.findClass(CLASS_PHONE_STATUS_BAR, classLoader);
                 XposedHelpers.findAndHookMethod(classPhoneStatusBar, "prepareNavigationBarView", prepareNavigationBarViewHook);
-
             }
 
         } catch (Throwable t) {

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/ui/SettingsActivity.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/ui/SettingsActivity.java
@@ -33,6 +33,8 @@ public class SettingsActivity extends Activity {
             getFragmentManager().beginTransaction().replace(R.id.fragment, new Fragment()).commit();
     }
 
+
+
     public static class Fragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
         @Override
@@ -80,7 +82,7 @@ public class SettingsActivity extends Activity {
             switch (key) {
                 case "double_tap_speed":
                     intent.setAction(ACTION_RECENTS_CHANGED);
-                    intent.putExtra(EXTRA_RECENTS_DOUBLE_TAP_SPEED, prefs.getInt(key, 400));
+                    intent.putExtra(EXTRA_RECENTS_DOUBLE_TAP_SPEED, prefs.getInt(key, 180));
                     break;
                 case "debug_log":
                     intent.setAction(ACTION_GENERAL);

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -41,7 +41,7 @@
     <string name="enable_recents">Activar modificações em recentes</string>
     <string name="enable_settings">Activar modificações nas definições</string>
     <string name="fix_sound_notif_tile">Algumas ROMs juntam o módulo de Sons e Notificações. Activar para mostrar o sumário correcto para estes casos</string>
-    <string name="fix_sound_notif_tile_title"><![CDATA[Corrigir o módulo de "Sons & Notificações"]]></string>
+    <string name="fix_sound_notif_tile_title">Corrigir o módulo de "Sons &amp; Notificações</string>
     <string name="header_recents">Recentes</string>
     <string name="header_settings">Definições</string>
     <!-- /RECENTS -->

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="xposed_description">Porta funções introduzidas no Android N a dispositivos com Lollipop e Marshmallow!</string>
+    <string name="xposed_description">Traz funções introduzidas no Android N a dispositivos com Lollipop e Marshmallow!</string>
 
     <string name="header_app">App</string>
 
     <!-- prefs -->
-    <string name="hide_launcher_icon">Pode requerer um reinício do launcher</string>
+    <string name="hide_launcher_icon">Pode ser necessário reiniciar o launcher</string>
     <string name="hide_launcher_icon_title">Esconder ícone do launcher</string>
     <string name="debug_log_title">Registos de depuração</string>
     <string name="debug_log">Atenção: Registo invasivo</string>
@@ -14,13 +14,13 @@
 
 
     <!-- SETTINGS -->
-    <string name="disabled">Desativado</string>
+    <string name="disabled">Desactivado</string>
     <string name="disconnected">Desconectado</string>
-    <string name="off">DESATIVADO</string>
-    <string name="on">ATIVADO</string>
+    <string name="off">DESACTIVADO</string>
+    <string name="on">ACTIVADO</string>
     <string name="data_usage_summary">%1$s de dados utilizados</string>
     <string name="display_summary">Brilho adaptável %1$s</string>
-    <string name="sound_summary">Volume da campainha em %1$s</string>
+    <string name="sound_summary">Volume do toque em %1$s</string>
     <string name="apps_summary">%1$d aplicações instaladas</string>
     <string name="storage_summary">%1$s de %2$s utilizados</string>
     <string name="battery_summary">%1$s - aprox. %2$s restantes</string>
@@ -29,14 +29,21 @@
     <string name="battery_charging_ac">%1$s - A carregar via CA</string>
     <string name="memory_summary">Utilização de memória %1$s de %2$s </string>
     <string name="user_summary">Conectado como %1$s</string>
-    <string name="location_on_power">ATIVADA / Poupança de energia</string>
-    <string name="location_on_device">ATIVADA / Apenas no dispositivo</string>
-    <string name="location_on_high">ATIVADA / Alta precisão</string>
+    <string name="location_on_power">ACTIVADA / Poupança de energia</string>
+    <string name="location_on_device">ACTIVADA / Apenas no dispositivo</string>
+    <string name="location_on_high">ACTIVADA / Alta precisão</string>
     <string name="print_summary">%1$d trabalhos de impressão</string>
     <!-- /SETTINGS -->
 
     <!-- RECENTS -->
     <string name="no_previous_recents">Nenhuma app recente</string>
+    <string name="double_tap_speed_title">Velocidade de duplo toque</string>
+    <string name="enable_recents">Activar modificações em recentes</string>
+    <string name="enable_settings">Activar modificações nas definições</string>
+    <string name="fix_sound_notif_tile">Algumas ROMs juntam o módulo de Sons e Notificações. Activar para mostrar o sumário correcto para estes casos</string>
+    <string name="fix_sound_notif_tile_title"><![CDATA[Corrigir o módulo de "Sons & Notificações"]]></string>
+    <string name="header_recents">Recentes</string>
+    <string name="header_settings">Definições</string>
     <!-- /RECENTS -->
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -34,7 +34,7 @@
             minimum="100"
             monitorBoxEnabled="true"
             monitorBoxUnit="ms"
-            android:defaultValue="120"
+            android:defaultValue="180"
             android:dependency="enable_recents_tweaks"
             android:key="double_tap_speed"
             android:title="@string/double_tap_speed_title"/>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -34,7 +34,7 @@
             minimum="100"
             monitorBoxEnabled="true"
             monitorBoxUnit="ms"
-            android:defaultValue="400"
+            android:defaultValue="120"
             android:dependency="enable_recents_tweaks"
             android:key="double_tap_speed"
             android:title="@string/double_tap_speed_title"/>


### PR DESCRIPTION
SW module was not reacting to changes in double-tap speed value. abstracted it and moved the broadcast receiver to the parent class. also, these values were not being read on module load.

took the opportunity to update pt_PT string as well  