### PR TITLE
Fix strings IT

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -75,7 +75,7 @@
     <!-- /RECENTS -->
     
     <!-- NOTIFICATIONS -->
-    <string name="enable_qs_in_header">Abilita i quicksettings nell\'intestazioner</string>
+  <!--  <string name="enable_qs_in_header">Abilita i quicksettings nell\'intestazioner</string> -->
     <string name="notification_header_qs_tiles_count">Numero massimo di quicksettings da mostrare</string>
     <string name="notification_header_qs_tiles_count_monitor">tiles</string>
     <string name="notifications_change_style">Notifiche con lo stile di Android N</string>


### PR DESCRIPTION
Fix a Extra-translation
From Gradle build:

:app:lintVitalRelease
C:\Users\vlwww\Desktop\AndroidN-ify\app\src\main\res\values-it\strings.xml:78: Error: "enable_qs_in_header" is translated here but not found in default locale [ExtraTranslation]
    <string name="enable_qs_in_header">Abilita i quicksettings nell\'intestazioner</string>
            ~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "ExtraTranslation":
   If a string appears in a specific language translation file, but there is
   no corresponding string in the default locale, then this string is probably
   unused. (It's technically possible that your application is only intended
   to run in a specific locale, but it's still a good idea to provide a
   fallback.).

   Note that these strings can lead to crashes if the string is looked up on
   any locale not providing a translation, so it's important to clean them
   up.

1 errors, 0 warnings