### PR TITLE
Fix status bar header on Motorola devices

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/notifications/StatusBarHeaderHooks.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/notifications/StatusBarHeaderHooks.java
@@ -682,6 +682,22 @@ public class StatusBarHeaderHooks {
                         params.height = ResourceUtils.getInstance(liparam.view.getContext()).getDimensionPixelSize(R.dimen.status_bar_header_height);
                     }
                 });
+                
+                // For Motorola stock roms only
+                try {
+                    resparam.res.hookLayout(PACKAGE_SYSTEMUI, "layout", "zz_moto_status_bar_expanded_header", new XC_LayoutInflated() {
+                        @Override
+                        public void handleLayoutInflated(LayoutInflatedParam liparam) throws Throwable {
+                            liparam.view.setElevation(0);
+                            liparam.view.setPadding(0, 0, 0, 0);
+                            FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) liparam.view.getLayoutParams();
+                            params.height = ResourceUtils.getInstance(liparam.view.getContext()).getDimensionPixelSize(R.dimen.status_bar_header_height);
+                        }
+                    });
+                } catch (Throwable ignore) {
+                    // Don't do anything here
+                }
+                
                 resparam.res.hookLayout(PACKAGE_SYSTEMUI, "layout", "qs_panel", new XC_LayoutInflated() {
                     @Override
                     public void handleLayoutInflated(LayoutInflatedParam liparam) throws Throwable {


### PR DESCRIPTION
Motorola decided to use a different layout file for the status bar header. Only God knows why. -.-
So let's hook into that layout if it exists.

A suggestion: Implement a GravityBox-like ROM detection logic. So we'll know which layouts to hook into.