### PR TITLE
workaround for fancy animation on CM13

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/notifications/QuickQSPanel.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/notifications/QuickQSPanel.java
@@ -166,7 +166,7 @@ public class QuickQSPanel extends LinearLayout {
         boolean readyToAnimate = !(mTranslationXAnimator == null || mTranslationYAnimator == null || mFirstPageDelayedAnimator == null || mTopFiveQsAnimator == null);
         boolean disableTranslation = StatusBarHeaderHooks.mDisableFancy;
         if (!readyToAnimate && (NotificationPanelHooks.getStatusBarState() != NotificationPanelHooks.STATE_KEYGUARD)) {
-            setupAnimators();
+            return;
         }
         if (!StatusBarHeaderHooks.mShowingDetail || f == 0) {
             if (oldPosition == 1 && f != oldPosition) {
@@ -200,13 +200,15 @@ public class QuickQSPanel extends LinearLayout {
                 }
                 mFirstPageDelayedAnimator.setPosition(f);
                 mTopFiveQsAnimator.setPosition(f);
-                if (mShowPercent && oldPosition < 0.7f && f >= 0.7f) {
-                    mBatteryView.setShowPercent(false);
-                    mBatteryView.postInvalidate();
-                }
-                if (mShowPercent && oldPosition >= 0.7f && f < 0.7f) {
-                    mBatteryView.setShowPercent(true);
-                    mBatteryView.postInvalidate();
+                if (mBatteryView != null) {
+                    if (mShowPercent && oldPosition < 0.7f && f >= 0.7f) {
+                        mBatteryView.setShowPercent(false);
+                        mBatteryView.postInvalidate();
+                    }
+                    if (mShowPercent && oldPosition >= 0.7f && f < 0.7f) {
+                        mBatteryView.setShowPercent(true);
+                        mBatteryView.postInvalidate();
+                    }
                 }
             }
             oldPosition = f;


### PR DESCRIPTION
also fix NPE if no battery tile is present

tested on CM13

The 5 at https://github.com/Unpublished/AndroidN-ify/blob/120ee5e12c53aaa6da22143924b332ba1f44fcbc/app/src/main/java/tk/wasdennnoch/androidn_ify/notifications/StatusBarHeaderHooks.java#L434 maybe needs to be increased on slower devices.

I know it's a bit hacky but it finally works :D
fixes #355