### PR TITLE
Fix opaque bolt not appearing & exclude emergency info from recents

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/phone/emergency/EmergencyButtonWrapper.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/phone/emergency/EmergencyButtonWrapper.java
@@ -86,7 +86,7 @@ public class EmergencyButtonWrapper implements View.OnClickListener {
         try {
             XposedHook.logI("androidn_ify", "try");
             mContext.startActivity(new Intent("tk.wasdennnoch.androidn_ify.ui.EmergencyInfoActivity")
-                    .setClassName("tk.wasdennnoch.androidn_ify", EmergencyInfoActivity.class.getName()));
+                    .setClassName("tk.wasdennnoch.androidn_ify", EmergencyInfoActivity.class.getName()).setFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS));
         } catch (Exception e) {
             XposedHook.logI("androidn_ify", "catch");
             XposedHook.logE(TAG, "Unable to start emergency activity!", e);

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/qs/tiles/BatteryTile.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/qs/tiles/BatteryTile.java
@@ -300,6 +300,7 @@ public class BatteryTile extends QSTile implements BatteryInfoManager.BatterySta
             mShapePath.lineTo(mButtonFrame.left, mFrame.top);
             mShapePath.lineTo(mButtonFrame.left, mButtonFrame.top);
 
+            boolean willDrawBolt = false;
             if (mBatteryData.charging) {
                 // define the bolt shape
                 final float bl = mFrame.left + mFrame.width() / 4.5f;
@@ -326,8 +327,8 @@ public class BatteryTile extends QSTile implements BatteryInfoManager.BatterySta
                 float boltPct = (mBoltFrame.bottom - levelTop) / (mBoltFrame.bottom - mBoltFrame.top);
                 boltPct = Math.min(Math.max(boltPct, 0), 1);
                 if (boltPct <= BOLT_LEVEL_THRESHOLD) {
-                    // draw the bolt if opaque
-                    c.drawPath(mBoltPath, mBoltPaint);
+                    // draw the bolt later
+                    willDrawBolt = true;
                 } else {
                     // otherwise cut the bolt out of the overall shape
                     mShapePath.op(mBoltPath, Path.Op.DIFFERENCE);
@@ -375,6 +376,9 @@ public class BatteryTile extends QSTile implements BatteryInfoManager.BatterySta
                     // draw the percentage text
                     c.drawText(pctText, pctX, pctY, mTextPaint);
                 }
+            } else if(willDrawBolt) {
+                // draw the bolt
+                c.drawPath(mBoltPath, mBoltPaint);
             }
         }
 


### PR DESCRIPTION
For some reason, drawing it before drawing the frame doesn't work.