### PR TITLE
Grant SystemUI BATTERY_STATS permissions

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/SystemUIHooks.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/SystemUIHooks.java
@@ -97,6 +97,13 @@ public class SystemUIHooks {
                 }, 2000);
             }
         });
+        
+        XposedHelpers.findAndHookMethod("android.app.ContextImpl", classLoader, "enforceCallingPermission", String.class, String.class, new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                if (param.args[0].equals("android.permission.BATTERY_STATS")) param.setResult(null);
+            }
+        });
 
     }
 


### PR DESCRIPTION
This fixes #754 partially. On my device I can now see the battery stats in the panel without a SystemUI crash.