### PR TITLE
Fix for white space under volume panel on OxygenOS 3.5.X

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/notifications/NotificationHooks.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/notifications/NotificationHooks.java
@@ -73,6 +73,7 @@ import tk.wasdennnoch.androidn_ify.systemui.statusbar.StatusBarHooks;
 import tk.wasdennnoch.androidn_ify.utils.ConfigUtils;
 import tk.wasdennnoch.androidn_ify.utils.RemoteMarginLinearLayout;
 import tk.wasdennnoch.androidn_ify.utils.ResourceUtils;
+import tk.wasdennnoch.androidn_ify.utils.RomUtils;
 import tk.wasdennnoch.androidn_ify.utils.ViewUtils;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
@@ -655,6 +656,9 @@ public class NotificationHooks {
     private static final XC_MethodHook updateWindowWidthHHook = new XC_MethodHook() {
         @Override
         protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+            if (RomUtils.isOxygen35()) {
+                return;
+            }
             Dialog mDialog = (Dialog) XposedHelpers.getObjectField(param.thisObject, "mDialog");
             ViewGroup mDialogView = (ViewGroup) XposedHelpers.getObjectField(param.thisObject, "mDialogView");
             Context context = mDialogView.getContext();
@@ -1244,7 +1248,7 @@ public class NotificationHooks {
                         Context context = action.getContext();
                         ResourceUtils res = ResourceUtils.getInstance(context);
                         int width_height = res.getDimensionPixelSize(R.dimen.notification_media_action_width);
-                        RelativeLayout.LayoutParams lParams = new RelativeLayout.LayoutParams(width_height,width_height);
+                        RelativeLayout.LayoutParams lParams = new RelativeLayout.LayoutParams(width_height, width_height);
                         lParams.setMarginEnd(res.getDimensionPixelSize(R.dimen.notification_media_action_margin));
                         int padding = ResourceUtils.getInstance(context).getDimensionPixelSize(R.dimen.notification_media_action_padding);
                         action.setPadding(0, padding, 0, padding);

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/notifications/NotificationPanelHooks.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/systemui/notifications/NotificationPanelHooks.java
@@ -166,11 +166,10 @@ public class NotificationPanelHooks {
         }
     }
 
-    public static boolean isOnKeyguard() {
-        return getStatusBarState() == NotificationPanelHooks.STATE_KEYGUARD;
-    }
-
     public static int getStatusBarState() {
+        if (mNotificationPanelView == null) {
+            return 0;
+        }
         return XposedHelpers.getIntField(mNotificationPanelView, "mStatusBarState");
     }
 

--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/utils/RomUtils.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/utils/RomUtils.java
@@ -26,6 +26,7 @@ public class RomUtils {
     // Init from Xposed
     public static void init(XSharedPreferences prefs) {
         sPrefs = prefs;
+        isOxygen35();
     }
     public static void initRemote() {
         Context context = (Context) XposedHelpers.callMethod(XposedHelpers.callStaticMethod(XposedHelpers.findClass("android.app.ActivityThread", null), "currentActivityThread"), "getSystemContext");
@@ -36,11 +37,6 @@ public class RomUtils {
     @SuppressLint("CommitPrefEdits")
     private static void checkRom() {
         if (sPrefs.contains("rom")) return;
-        String rrVersion = SystemProperties.get("ro.rr.version", "");
-        if (!"".equals(rrVersion)) {
-            sPrefs.edit().putString("rom", "rr").commit();
-            return;
-        }
         String aicpVersion = SystemProperties.get("ro.aicp.version", "");
         if (!aicpVersion.equals("")) {
             sPrefs.edit().putString("rom", "aicp").commit();
@@ -58,18 +54,17 @@ public class RomUtils {
         return StatusBarHeaderHooks.mUseDragPanel;
     }
 
-    public static boolean isRr() {
-        return sPrefs.getString("rom", "").equals("rr");
-    }
-
     public static boolean isAicp() {
         return sPrefs.getString("rom", "").equals("aicp");
+    }
+
+    public static boolean isOxygen35() {
+        return SystemProperties.get("ro.oxygen.version", "").contains("3.5");
     }
 
     public static boolean isCmBased() {
         String rom = sPrefs.getString("rom", "");
         switch (rom) {
-            case "rr":
             case "aicp":
             case "cm":
                 return true;


### PR DESCRIPTION
Disable a Volume Panel hook on OxygenOS 3.5, as it has its own solutions, and check for null additionally.

This solution is developed by wDCat, and modified by aviraxp.

I am going to check if there are other roms like H2OS that suffer from this issue.

I do not use the provided checkRom() method, because it seems that default.prop can only be read when system boots up, and it gives false negative when using this method. Also did some clean ups.