### PR TITLE
Fix crash when opening Battery settings in some cases

### DIFF
--- a/app/src/main/java/tk/wasdennnoch/androidn_ify/settings/SettingsHooks.java
+++ b/app/src/main/java/tk/wasdennnoch/androidn_ify/settings/SettingsHooks.java
@@ -110,7 +110,7 @@ public class SettingsHooks {
         Object mChart = XposedHelpers.getAdditionalInstanceField(preference, KEY_CHART);
         if (field != null && field instanceof BatteryInfo) {
             if (view.findViewById(R.id.battery_usage) == null) {
-                FrameLayout oldLayout = (FrameLayout) view;
+                ViewGroup oldLayout = (ViewGroup) view;
                 oldLayout.removeAllViews();
 
                 Context context = oldLayout.getContext();


### PR DESCRIPTION
In some roms the Battery settings uses a LinearLayout instead of a FrameLayout.
A ClassCastException is thrown in such roms causing a 'Unfortunately, Settings has stopped.'.
Because they both extend ViewGroup and no other specific FrameLayout code seems to be used changing it to ViewGroup works just as well.
Fix tested on Moto Z Play 6.0.1 MPN24.104-25.

Stacktrace of crash before fix:
`07-28 08:19:18.831 10640 10640 E AndroidRuntime: java.lang.ClassCastException: android.widget.LinearLayout cannot be cast to android.widget.FrameLayout
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at tk.wasdennnoch.androidn_ify.settings.SettingsHooks.bindBatteryHistoryPreference(SettingsHooks.java:113)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at tk.wasdennnoch.androidn_ify.settings.SettingsHooks.access$000(SettingsHooks.java:42)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at tk.wasdennnoch.androidn_ify.settings.SettingsHooks$2.replaceHookedMethod(SettingsHooks.java:83)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at de.robv.android.xposed.XC_MethodReplacement.beforeHookedMethod(XC_MethodReplacement.java:29)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at de.robv.android.xposed.XposedBridge.handleHookedMethod(XposedBridge.java:314)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at com.android.settings.fuelgauge.BatteryHistoryPreference.onBindView(<Xposed>)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at android.preference.Preference.getView(Preference.java:495)
07-28 08:19:18.831 10640 10640 E AndroidRuntime: at android.preference.PreferenceGroupAdapter.getView(PreferenceGroupAdapter.java:246)
....
....`